### PR TITLE
Add Lumitree to the webring

### DIFF
--- a/static/webring/froglist.json
+++ b/static/webring/froglist.json
@@ -118,5 +118,11 @@
     "url": "https://duskworks.net/",
     "displayName": "Firefly in the Dusk🌙",
     "description": "Personal site where I write about my game engine and other projects."
+  },
+  {
+    "name": "lumitree",
+    "url": "https://lumitree.art/",
+    "displayName": "Lumitree",
+    "description": "A collaborative art project where visitors plant seeds that grow into interactive micro-worlds using generative graphics."
   }
 ]


### PR DESCRIPTION
## Adding Lumitree to the Graphics Programming Webring

**Site:** [lumitree.art](https://lumitree.art/)

Lumitree is a collaborative art project where visitors plant seeds that grow into interactive micro-worlds. Each micro-world is a self-contained HTML file (<50KB) using a different generative graphics technique:

- Canvas 2D particle systems and flow fields
- WebGL/GLSL shader art (SDF raymarching, fractal noise)
- L-systems and procedural growth
- Cellular automata
- Web Audio API sound gardens

The webring navigation links have been added to the site's page footers (explore page and individual world pages).

**Entry added:**
```json
{
  "name": "lumitree",
  "url": "https://lumitree.art/",
  "displayName": "Lumitree",
  "description": "A collaborative art project where visitors plant seeds that grow into interactive micro-worlds using generative graphics."
}
```