### PR TITLE
Add barrettw to webring froglist

### DIFF
--- a/static/webring/froglist.json
+++ b/static/webring/froglist.json
@@ -130,5 +130,11 @@
   "url": "https://saswatjk.github.io/personal-site/index.html",
   "displayName": "Saswat Jung Khadka",
   "description": "Personal site with my projects and my blog, which includes graphics and other things."
+  },
+  {
+    "name": "barrettw",
+    "url": "https://barrettw.net/",
+    "displayName": "Barrett Wise",
+    "description": "Personal portfolio of Barrett Wise — software engineer and graphics programming enthusiast."
   }
 ]


### PR DESCRIPTION
## Joining the GP webring

Adding my site to the webring froglist per the [join instructions](https://graphics-programming.org/webring/join).

### New entry
```json
{
  "name": "barrettw",
  "url": "https://barrettw.net/",
  "displayName": "Barrett Wise",
  "description": "Personal portfolio of Barrett Wise — software engineer and graphics programming enthusiast."
}
```

- `name` is short and URL-friendly (used in the `/webring/frogs/barrettw/{prev,next}` links).
- `url` is my homepage, visible from the landing page.
- Webring nav links (⬅️ froge ➡️) are already live in my site footer.

Thanks for maintaining the webring! 🐸